### PR TITLE
Modernize syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 'use strict';
 
-var program = require('commander');
-var core = require('./lib/core');
+const program = require('commander');
+const core = require('./lib/core');
 
-var words = [];
+let words = [];
 program
   .version(core.VERSION)
   .option(

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var jsonFile = require('jsonfile');
-var merge = require('merge');
-var untildify = require('untildify');
+const jsonFile = require('jsonfile');
+const merge = require('merge');
+const untildify = require('untildify');
 
-var util = require('./util');
+const util = require('./util');
 
 /**
  * Module for handling configuration. A config object contains information
@@ -34,11 +34,11 @@ var util = require('./util');
  */
 exports.resolveConfig = function(cliArgs) {
   // Our general order here is command line, file, defaults.
-  var configFromDefaults = exports.getDefaultConfig();
-  var configFromCli = exports.getCliConfig(cliArgs);
-  var configFromFile = exports.getFileConfig(cliArgs.configFile);
+  const configFromDefaults = exports.getDefaultConfig();
+  const configFromCli = exports.getCliConfig(cliArgs);
+  const configFromFile = exports.getFileConfig(cliArgs.configFile);
 
-  var resolvedConfig = merge(
+  const resolvedConfig = merge(
     true, configFromDefaults, configFromFile, configFromCli
   );    
 
@@ -52,7 +52,7 @@ exports.resolveConfig = function(cliArgs) {
  * @return {Object} a config object based solely on defaults
  */
 exports.getDefaultConfig = function() {
-  var result = exports.buildConfig(
+  const result = exports.buildConfig(
     exports.getEditorCmdFromEnv()
   );
   return result;
@@ -110,7 +110,7 @@ exports.validateConfig = function(config) {
     );
   } else {
     Object.keys(config.notebooks).forEach(nbName => {
-      var notebook = config.notebooks[nbName];
+      const notebook = config.notebooks[nbName];
       if (!notebook.path) {
         util.failAndQuit(
           new Error('Notebook missing a path in .tanager.json, failing fast.')
@@ -128,8 +128,8 @@ exports.validateConfig = function(config) {
  */
 exports.expandConfigPaths = function(config) {
   Object.keys(config.notebooks).forEach(nbName => {
-    var notebook = config.notebooks[nbName];
-    var expandedPath = untildify(notebook.path);
+    const notebook = config.notebooks[nbName];
+    const expandedPath = untildify(notebook.path);
     notebook.path = expandedPath;
   });
 };
@@ -144,7 +144,7 @@ exports.expandConfigPaths = function(config) {
  * @return {Object} a config object
  */
 exports.buildConfig = function(editorCmd) {
-  var result = {};
+  const result = {};
   if (editorCmd) {
     result.editorCmd = editorCmd;
   }
@@ -160,7 +160,7 @@ exports.buildConfig = function(editorCmd) {
  * truthy.
  */
 exports.resolvePriority = function(arr) {
-  for (var i = 0; i < arr.length; i++) {
+  for (let i = 0; i < arr.length; i++) {
     if (arr[i]) {
       return arr[i];
     }
@@ -173,7 +173,7 @@ exports.resolvePriority = function(arr) {
  */
 exports.getEditorCmdFromEnv = function() {
   // We want precedence of command line, config, VISUAL, EDITOR, as with git.
-  var result = exports.resolvePriority([
+  const result = exports.resolvePriority([
     process.env.VISUAL, process.env.EDITOR
   ]);
   return result;

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var childProcess = require('child_process');
-var chrono = require('chrono-node');
-var mkdirp = require('mkdirp');
-var moment = require('moment');
-var path = require('path');
-var untildify = require('untildify');
+const childProcess = require('child_process');
+const chrono = require('chrono-node');
+const mkdirp = require('mkdirp');
+const moment = require('moment');
+const path = require('path');
+const untildify = require('untildify');
 
-var config = require('./config');
-var util = require('./util');
+const config = require('./config');
+const util = require('./util');
 
 // Also bump in package.json
 exports.VERSION = '0.0.3';
@@ -36,7 +36,7 @@ exports.DEFAULT_FILE_SUFFIX = '.md';
  * represent the title. Zero length array indicates no words submitted.
  */
 exports.handleRawInput = function(args, words) {
-  var date = args.date;
+  let date = args.date;
   if (date) {
     // They've specified a date at the command line. Use it.
     date = chrono.parseDate(date);
@@ -44,7 +44,7 @@ exports.handleRawInput = function(args, words) {
     date = exports.getNow();
   }
 
-  var cfg = config.resolveConfig(args);
+  const cfg = config.resolveConfig(args);
   exports.handleValidatedInput(cfg, date, words);
 };
 
@@ -63,7 +63,7 @@ exports.getNow = function() {
  * represent the title.
  */
 exports.handleValidatedInput = function(config, date, words) {
-  var notebook = exports.getNotebook(config, words);
+  const notebook = exports.getNotebook(config, words);
 
   if (config.editRecent) {
     exports.editLastModifiedFile(config, notebook);
@@ -75,8 +75,8 @@ exports.handleValidatedInput = function(config, date, words) {
     return;
   }
 
-  var entryPath = exports.getEntryPath(notebook, date, words); 
-  var editorCmd = config.editorCmd;
+  const entryPath = exports.getEntryPath(notebook, date, words); 
+  const editorCmd = config.editorCmd;
 
   exports.editEntry(editorCmd, entryPath);
 };
@@ -100,7 +100,7 @@ exports.printNotebookPath = function(notebook) {
  */
 exports.editLastModifiedFile = function(config, notebook) {
   return new Promise(function(resolve, reject) {
-    var suffixes = [ exports.DEFAULT_FILE_SUFFIX ];
+    const suffixes = [ exports.DEFAULT_FILE_SUFFIX ];
     util.getLastModifiedFile(notebook.path, suffixes)
     .then(entryPath => {
       if (!entryPath) {
@@ -136,14 +136,14 @@ exports.editEntry = function(editorCmd, entryPath) {
  * @return {Object} the notebook object to which this invocation applies
  */
 exports.getNotebook = function(config, words) {
-  var notebooks = exports.getNotebooks(config);
-  var notebook = null;
+  const notebooks = exports.getNotebooks(config);
+  let notebook = null;
 
   if (words.length > 0 && notebooks.hasOwnProperty(words[0])) {
     notebook = notebooks[words[0]];
   } else {
     Object.keys(notebooks).forEach(key => {
-      var nb = notebooks[key];
+      const nb = notebooks[key];
       if (nb.default) {
         notebook = nb;
       }
@@ -169,19 +169,19 @@ exports.getNotebook = function(config, words) {
  * the file all will exist.
  */
 exports.getEntryPath = function(notebook, date, words) {
-  var datem = moment(date);
-  var yearStr = '' + datem.year();
-  var dateName = datem.format(exports.DATE_FORMAT);
+  const datem = moment(date);
+  const yearStr = '' + datem.year();
+  const dateName = datem.format(exports.DATE_FORMAT);
   
-  var text = exports.getEntryTitleWords(notebook, words);
+  let text = exports.getEntryTitleWords(notebook, words);
   text += exports.DEFAULT_FILE_SUFFIX;
   
-  var fileName = dateName + exports.DATE_TITLE_DELIMITER + text;
+  const fileName = dateName + exports.DATE_TITLE_DELIMITER + text;
 
-  var dir = path.join(notebook.path, yearStr);
+  const dir = path.join(notebook.path, yearStr);
   mkdirp.sync(dir);
 
-  var result = path.join(dir, fileName);
+  const result = path.join(dir, fileName);
   return result;
 };
 
@@ -225,12 +225,12 @@ exports.getEntryTitleWords = function(notebook, words) {
  * callers down the line.
  */
 exports.getNotebooks = function(config) {
-  var result = {};
+  const result = {};
   Object.keys(config.notebooks).forEach(notebookName => {
-    var rawNb = config.notebooks[notebookName];
+    const rawNb = config.notebooks[notebookName];
     // Don't mutate the config object. No real reason to be careful of this
     // other than trying to prevent side effects.
-    var resolvedNb = JSON.parse(JSON.stringify(rawNb));
+    const resolvedNb = JSON.parse(JSON.stringify(rawNb));
     resolvedNb.path = untildify(rawNb.path);
     // Add the _name key we add for convenience
     resolvedNb._name = notebookName;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var bluebird = require('bluebird');
-var fs = require('fs');
-var glob = require('glob');
+const bluebird = require('bluebird');
+const fs = require('fs');
+const glob = require('glob');
 
-var statPromisified = bluebird.promisify(fs.stat);
+const statPromisified = bluebird.promisify(fs.stat);
 
 /**
  * @return {Promise} promisified version of fs.stat called with path
@@ -36,7 +36,7 @@ exports.failAndQuit = function(err) {
  */
 exports.getLastModifiedFile = function(dir, suffixes) {
   return new Promise(function(resolve, reject) {
-    var fileNames = null;
+    let fileNames = null;
     exports.getFilesInDirectory(dir, suffixes)
     .then(files => {
       if (files.length === 0) {
@@ -44,7 +44,7 @@ exports.getLastModifiedFile = function(dir, suffixes) {
         return;
       }
       fileNames = files;
-      var statPromises = [];
+      const statPromises = [];
       files.forEach(file => {
         statPromises.push(exports.statPromisified(file));
       });
@@ -52,10 +52,10 @@ exports.getLastModifiedFile = function(dir, suffixes) {
       return Promise.all(statPromises);
     })
     .then(stats => {
-      var result = fileNames[0];
-      var resultTime = stats[0].mtime;
-      for (var i = 0; i < stats.length; i++) {
-        var stat = stats[i];
+      let result = fileNames[0];
+      let resultTime = stats[0].mtime;
+      for (let i = 0; i < stats.length; i++) {
+        const stat = stats[i];
         if (stat.mtime > resultTime) {
           result = fileNames[i];
           resultTime = stat.mtime;
@@ -86,13 +86,13 @@ exports.getFilesInDirectory = function(dir, suffixes) {
     // wants forward slashes for separators.
     // Strangely, **/*.md is not equivalent to **/*{.md}. We will thus only use
     // curly braces when necessary.
-    var suffixPattern = '';
+    let suffixPattern = '';
     if (suffixes.length === 1) {
       suffixPattern = suffixes[0];
     } else if (suffixes.length > 1) {
       suffixPattern = '{' + suffixes.join(',') + '}';
     }
-    var pattern = '**/*' + suffixPattern;
+    const pattern = '**/*' + suffixPattern;
     glob(pattern, { cwd: dir, absolute: true }, function(err, files) {
       if (err) {
         reject(err);

--- a/test/lib/config-test.js
+++ b/test/lib/config-test.js
@@ -3,7 +3,7 @@
 var merge = require('merge');
 var proxyquire = require('proxyquire');
 var sinon = require('sinon');
-var tape = require('tape');
+var test = require('tape');
 require('sinon-as-promised');
 
 var config = require('../../lib/config');
@@ -46,7 +46,7 @@ function getValidConfig() {
   return cfg;
 }
 
-tape('resolveConfig relies on default', function(t) {
+test('resolveConfig relies on default', function(t) {
   var cliArgs = {
     configFile: '/path/to/config/file',
     editorCmd: 'vim -e'
@@ -92,7 +92,7 @@ tape('resolveConfig relies on default', function(t) {
   end(t);
 });
 
-tape('validateConfig does nothing if all well', function(t) {
+test('validateConfig does nothing if all well', function(t) {
   var cfg = getValidConfig();
 
   var failStub = sinon.stub();
@@ -107,7 +107,7 @@ tape('validateConfig does nothing if all well', function(t) {
   end(t);
 });
 
-tape('validateConfig exits if invalid', function(t) {
+test('validateConfig exits if invalid', function(t) {
   // Start with a valid config and delete things.
   var cfg = {
     editorCmd: 'vim -e',
@@ -153,7 +153,7 @@ tape('validateConfig exits if invalid', function(t) {
   end(t);
 });
 
-tape('expandConfigPaths expands paths', function(t) {
+test('expandConfigPaths expands paths', function(t) {
   var cfg = {
     notebooks: {
       journal: {
@@ -181,14 +181,14 @@ tape('expandConfigPaths expands paths', function(t) {
   end(t);
 });
 
-tape('buildConfig respects nulls', function(t) {
+test('buildConfig respects nulls', function(t) {
   var expected = {};
   var actual = config.buildConfig(undefined);
   t.deepEqual(actual, expected);
   end(t);
 });
 
-tape('buildConfig returns expected', function(t) {
+test('buildConfig returns expected', function(t) {
   var cmd = 'vim -e';
   var expected = { editorCmd: cmd };
   var actual = config.buildConfig(cmd);
@@ -196,7 +196,7 @@ tape('buildConfig returns expected', function(t) {
   end(t);
 });
 
-tape('resolvePriority returns first truthy value', function(t) {
+test('resolvePriority returns first truthy value', function(t) {
   var arr = ['foo', 'bar'];
   t.equal(config.resolvePriority(arr), arr[0]);
 
@@ -206,12 +206,12 @@ tape('resolvePriority returns first truthy value', function(t) {
   end(t);
 });
 
-tape('resolvePriority returns null if no truthy values', function(t) {
+test('resolvePriority returns null if no truthy values', function(t) {
   t.equal(config.resolvePriority([null, undefined, false]), null);
   end(t);
 });
 
-tape('getEditorCmdFromEnv resolves and returns', function(t) {
+test('getEditorCmdFromEnv resolves and returns', function(t) {
   var resolvePriorityStub = sinon.stub().returns();
   config.resolvePriority = resolvePriorityStub;
 
@@ -224,7 +224,7 @@ tape('getEditorCmdFromEnv resolves and returns', function(t) {
   end(t);
 });
 
-tape('getFileConfig resolves path and returns contents', function(t) {
+test('getFileConfig resolves path and returns contents', function(t) {
   var configPath = '~/path/to/config.json';
   var resolvedPath = '/abs/path';
 
@@ -242,7 +242,7 @@ tape('getFileConfig resolves path and returns contents', function(t) {
   end(t);
 });
 
-tape('getDefaultConfig returns defaults', function(t) {
+test('getDefaultConfig returns defaults', function(t) {
   var defaultEditor = 'Marked2';
   config.getEditorCmdFromEnv = sinon.stub().returns(defaultEditor);
   var expected = { editorCmd: defaultEditor };
@@ -251,7 +251,7 @@ tape('getDefaultConfig returns defaults', function(t) {
   end(t);
 });
 
-tape('getCliConfig handles custom params', function(t) {
+test('getCliConfig handles custom params', function(t) {
   var cliEditor = 'emacs';
   var expected = {
     editorCmd: cliEditor,
@@ -267,7 +267,7 @@ tape('getCliConfig handles custom params', function(t) {
   end(t);
 });
 
-tape('getCliConfig handles defaults', function(t) {
+test('getCliConfig handles defaults', function(t) {
   var expected = {
     editRecent: false,
     pwd: false,

--- a/test/lib/config-test.js
+++ b/test/lib/config-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var merge = require('merge');
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var test = require('tape');
+const merge = require('merge');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
 require('sinon-as-promised');
 
-var config = require('../../lib/config');
+let config = require('../../lib/config');
 
 /**
  * Manipulating the object directly leads to polluting the require cache. Any
@@ -35,7 +35,7 @@ function end(t) {
 }
 
 function getValidConfig() {
-  var cfg = {
+  const cfg = {
     editorCmd: 'vim -e',
     notebooks: {
       journal: {
@@ -47,29 +47,29 @@ function getValidConfig() {
 }
 
 test('resolveConfig relies on default', function(t) {
-  var cliArgs = {
+  const cliArgs = {
     configFile: '/path/to/config/file',
     editorCmd: 'vim -e'
   };
 
-  var defaultConfig = {
+  const defaultConfig = {
     defOnly: 'from default',
     fileRules: 'from default',
     cliRules: 'from default'
   };
 
-  var fileConfig = {
+  const fileConfig = {
     fileOnly: 'from file',
     fileRules: 'from file',
     cliRules: 'from file'
   };
 
-  var cliConfig = {
+  const cliConfig = {
     cliOnly: 'from cli',
     cliRules: 'from cli'
   };
 
-  var expected = {
+  const expected = {
     defOnly: defaultConfig.defOnly,
     fileOnly: fileConfig.fileOnly,
     cliOnly: cliConfig.cliOnly,
@@ -85,7 +85,7 @@ test('resolveConfig relies on default', function(t) {
   config.validateConfig = sinon.stub();
   config.expandConfigPaths = sinon.stub();
 
-  var actual = config.resolveConfig(cliArgs);
+  const actual = config.resolveConfig(cliArgs);
   t.deepEqual(actual, expected);
   t.deepEqual(config.validateConfig.args[0], [actual]);
   t.deepEqual(config.expandConfigPaths.args[0], [actual]);
@@ -93,9 +93,9 @@ test('resolveConfig relies on default', function(t) {
 });
 
 test('validateConfig does nothing if all well', function(t) {
-  var cfg = getValidConfig();
+  const cfg = getValidConfig();
 
-  var failStub = sinon.stub();
+  const failStub = sinon.stub();
   proxyquireConfig({
     './util': {
       failAndQuit: failStub
@@ -109,7 +109,7 @@ test('validateConfig does nothing if all well', function(t) {
 
 test('validateConfig exits if invalid', function(t) {
   // Start with a valid config and delete things.
-  var cfg = {
+  const cfg = {
     editorCmd: 'vim -e',
     notebooks: {
       journal: {
@@ -118,7 +118,7 @@ test('validateConfig exits if invalid', function(t) {
     }
   };
 
-  var failStub = sinon.stub();
+  const failStub = sinon.stub();
   proxyquireConfig({
     './util': {
       failAndQuit: failStub
@@ -126,7 +126,7 @@ test('validateConfig exits if invalid', function(t) {
   });
 
   // We'll use merge to copy things.
-  var noEditor = merge(true, cfg);
+  const noEditor = merge(true, cfg);
   delete(noEditor.editorCmd);
   config.validateConfig(noEditor);
   t.deepEqual(
@@ -134,7 +134,7 @@ test('validateConfig exits if invalid', function(t) {
     [new Error('Could not find editor. Try setting $VISUAL.')]
   );
 
-  var noNotebooks = merge(true, cfg);
+  const noNotebooks = merge(true, cfg);
   delete(noNotebooks.notebooks);
   config.validateConfig(noEditor);
   t.deepEqual(
@@ -142,7 +142,7 @@ test('validateConfig exits if invalid', function(t) {
     [new Error('No notebooks found. Set in .tanager.json')]
   );
 
-  var missingPath = merge(true, cfg);
+  const missingPath = merge(true, cfg);
   delete(missingPath.notebooks.journal.path);
   config.validateConfig(missingPath);
   t.deepEqual(
@@ -154,7 +154,7 @@ test('validateConfig exits if invalid', function(t) {
 });
 
 test('expandConfigPaths expands paths', function(t) {
-  var cfg = {
+  const cfg = {
     notebooks: {
       journal: {
         path: '~/a/b/c'
@@ -165,15 +165,15 @@ test('expandConfigPaths expands paths', function(t) {
     }
   };
 
-  var absJournalPath = '/abs/path/to/a/b/c';
+  const absJournalPath = '/abs/path/to/a/b/c';
 
-  var untildifyStub = sinon.stub();
+  const untildifyStub = sinon.stub();
   untildifyStub.withArgs(cfg.notebooks.journal.path).returns(absJournalPath);
   untildifyStub.withArgs(cfg.notebooks.notes.path)
     .returns(cfg.notebooks.notes.path);
   proxyquireConfig({ 'untildify': untildifyStub });
 
-  var expected = merge(true, cfg);
+  const expected = merge(true, cfg);
   expected.notebooks.journal.path = absJournalPath;
   // we modify cfg in place
   config.expandConfigPaths(cfg);
@@ -182,26 +182,26 @@ test('expandConfigPaths expands paths', function(t) {
 });
 
 test('buildConfig respects nulls', function(t) {
-  var expected = {};
-  var actual = config.buildConfig(undefined);
+  const expected = {};
+  const actual = config.buildConfig(undefined);
   t.deepEqual(actual, expected);
   end(t);
 });
 
 test('buildConfig returns expected', function(t) {
-  var cmd = 'vim -e';
-  var expected = { editorCmd: cmd };
-  var actual = config.buildConfig(cmd);
+  const cmd = 'vim -e';
+  const expected = { editorCmd: cmd };
+  const actual = config.buildConfig(cmd);
   t.deepEqual(actual, expected);
   end(t);
 });
 
 test('resolvePriority returns first truthy value', function(t) {
-  var arr = ['foo', 'bar'];
-  t.equal(config.resolvePriority(arr), arr[0]);
+  const firstTruthy = ['foo', 'bar'];
+  t.equal(config.resolvePriority(firstTruthy), firstTruthy[0]);
 
-  arr = [null, undefined, 'vim -e'];
-  t.equal(config.resolvePriority(arr), arr[2]);
+  const firstFalsey = [null, undefined, 'vim -e'];
+  t.equal(config.resolvePriority(firstFalsey), firstFalsey[2]);
 
   end(t);
 });
@@ -212,7 +212,7 @@ test('resolvePriority returns null if no truthy values', function(t) {
 });
 
 test('getEditorCmdFromEnv resolves and returns', function(t) {
-  var resolvePriorityStub = sinon.stub().returns();
+  const resolvePriorityStub = sinon.stub().returns();
   config.resolvePriority = resolvePriorityStub;
 
   config.getEditorCmdFromEnv();
@@ -225,10 +225,10 @@ test('getEditorCmdFromEnv resolves and returns', function(t) {
 });
 
 test('getFileConfig resolves path and returns contents', function(t) {
-  var configPath = '~/path/to/config.json';
-  var resolvedPath = '/abs/path';
+  const configPath = '~/path/to/config.json';
+  const resolvedPath = '/abs/path';
 
-  var expected = { expected: 'fileContents' };
+  const expected = { expected: 'fileContents' };
 
   proxyquireConfig({
     'untildify': sinon.stub().withArgs(configPath).returns(resolvedPath),
@@ -237,28 +237,28 @@ test('getFileConfig resolves path and returns contents', function(t) {
     }
   });
 
-  var actual = config.getFileConfig(configPath);
+  const actual = config.getFileConfig(configPath);
   t.deepEqual(actual, expected);
   end(t);
 });
 
 test('getDefaultConfig returns defaults', function(t) {
-  var defaultEditor = 'Marked2';
+  const defaultEditor = 'Marked2';
   config.getEditorCmdFromEnv = sinon.stub().returns(defaultEditor);
-  var expected = { editorCmd: defaultEditor };
-  var actual = config.getDefaultConfig();
+  const expected = { editorCmd: defaultEditor };
+  const actual = config.getDefaultConfig();
   t.deepEqual(actual, expected);
   end(t);
 });
 
 test('getCliConfig handles custom params', function(t) {
-  var cliEditor = 'emacs';
-  var expected = {
+  const cliEditor = 'emacs';
+  const expected = {
     editorCmd: cliEditor,
     editRecent: true,
     pwd: true,
   };
-  var actual = config.getCliConfig({
+  const actual = config.getCliConfig({
     editorCmd: cliEditor,
     editRecent: true,
     pwd: true,
@@ -268,11 +268,11 @@ test('getCliConfig handles custom params', function(t) {
 });
 
 test('getCliConfig handles defaults', function(t) {
-  var expected = {
+  const expected = {
     editRecent: false,
     pwd: false,
   };
-  var actual = config.getCliConfig({});
+  const actual = config.getCliConfig({});
   t.deepEqual(actual, expected);
   end(t);
 });

--- a/test/lib/core-test.js
+++ b/test/lib/core-test.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var path = require('path');
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var test = require('tape');
+const path = require('path');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
 require('sinon-as-promised');
 
-var core = require('../../lib/core');
+let core = require('../../lib/core');
 
 /**
  * Manipulating the object directly leads to polluting the require cache. Any
@@ -43,14 +43,14 @@ function createaCliArgs(configPath, date, editorCmd) {
 }
 
 test('handleRawInput parses given date and calls next', function(t) {
-  var path = 'path/to/config';
-  var date = new Date('2016-03-05T20:00:00.000Z');
-  var dateArg = 'yesterday';
-  var parseDateStub = sinon.stub().withArgs(dateArg).returns(date);
-  var config = { config: 'much value' };
-  var words = ['foo', 'bar'];
+  const path = 'path/to/config';
+  const date = new Date('2016-03-05T20:00:00.000Z');
+  const dateArg = 'yesterday';
+  const parseDateStub = sinon.stub().withArgs(dateArg).returns(date);
+  const config = { config: 'much value' };
+  const words = ['foo', 'bar'];
 
-  var cliArgs = createaCliArgs(path, date, null);
+  const cliArgs = createaCliArgs(path, date, null);
 
   proxyquireCore({
     'chrono-node': { parseDate: parseDateStub },
@@ -66,13 +66,13 @@ test('handleRawInput parses given date and calls next', function(t) {
 });
 
 test('handleRawInput gets now if no date given', function(t) {
-  var path = 'path/to/config';
-  var date = new Date('2015-03-05T20:00:00.000Z');
-  var dateArg = null;
-  var config = { config: 'much value' };
-  var words = ['foo', 'bar'];
+  const path = 'path/to/config';
+  const date = new Date('2015-03-05T20:00:00.000Z');
+  const dateArg = null;
+  const config = { config: 'much value' };
+  const words = ['foo', 'bar'];
 
-  var cliArgs = createaCliArgs(path, dateArg, null);
+  const cliArgs = createaCliArgs(path, dateArg, null);
 
   proxyquireCore({
     './config': {
@@ -89,7 +89,7 @@ test('handleRawInput gets now if no date given', function(t) {
 });
 
 test('handleRawInput calls fail and quit on err', function(t) {
-  var expected = { err: 'trouble' };
+  const expected = { err: 'trouble' };
 
   proxyquireCore({
     './config': {
@@ -97,7 +97,7 @@ test('handleRawInput calls fail and quit on err', function(t) {
     }
   }, true);
 
-  var shouldThrow = function() {
+  const shouldThrow = function() {
     core.handleRawInput({});
   };
 
@@ -106,15 +106,15 @@ test('handleRawInput calls fail and quit on err', function(t) {
 });
 
 test('handleValidatedInput opens editor', function(t) {
-  var notebook = { path: '/path/to/notebook' };
-  var entryPath = path.join(
+  const notebook = { path: '/path/to/notebook' };
+  const entryPath = path.join(
     notebook.path, '2016', '2016-03-05_lame-meeting.md'
   );
-  var words = ['lame', 'meeting'];
-  var config = { editorCmd: 'vim -e' };
-  var date = new Date();
+  const words = ['lame', 'meeting'];
+  const config = { editorCmd: 'vim -e' };
+  const date = new Date();
 
-  var editStub = sinon.stub();
+  const editStub = sinon.stub();
   core.editEntry = editStub;
 
   core.getNotebook = sinon.stub().withArgs(config, words).returns(notebook);
@@ -129,13 +129,13 @@ test('handleValidatedInput opens editor', function(t) {
 });
 
 test('handleValidatedInput calls editLastModifiedFile', function(t) {
-  var notebook = 'notebook';
-  var config = { editRecent: true };
-  var words = ['foo', 'bar'];
+  const notebook = 'notebook';
+  const config = { editRecent: true };
+  const words = ['foo', 'bar'];
 
-  var getNotebookStub = sinon.stub().withArgs(config, words).returns(notebook);
-  var editLastStub = sinon.stub();
-  var editEntryStub = sinon.stub();
+  const getNotebookStub = sinon.stub().withArgs(config, words).returns(notebook);
+  const editLastStub = sinon.stub();
+  const editEntryStub = sinon.stub();
 
   core.getNotebook = getNotebookStub;
   core.editLastModifiedFile = editLastStub;
@@ -171,8 +171,8 @@ test('handleValidatedInput handles pwd', function(t) {
 });
 
 test('editLastModifiedFile calls fail and rejects if error', function(t) {
-  var expected = { err: 'trubs' };
-  var getFileStub = sinon.stub().rejects(expected);
+  const expected = { err: 'trubs' };
+  const getFileStub = sinon.stub().rejects(expected);
 
   proxyquireCore({ './util':
     { getLastModifiedFile: getFileStub }
@@ -190,14 +190,14 @@ test('editLastModifiedFile calls fail and rejects if error', function(t) {
 });
 
 test('editLastModifiedFile calls editEntry with last file', function(t) {
-  var notebook = { path: '/Users/cersei/cute-joff' };
-  var config = { editorCmd: 'word' };  // Cersei seems like a Word user
+  const notebook = { path: '/Users/cersei/cute-joff' };
+  const config = { editorCmd: 'word' };  // Cersei seems like a Word user
 
-  var entryPath = '/Users/cersei/cute-joff/ten-years-later-first-entry.md';
+  const entryPath = '/Users/cersei/cute-joff/ten-years-later-first-entry.md';
 
-  var getFileStub = sinon.stub().withArgs(notebook.path, ['.md'])
+  const getFileStub = sinon.stub().withArgs(notebook.path, ['.md'])
     .resolves(entryPath);
-  var editEntryStub = sinon.stub();
+  const editEntryStub = sinon.stub();
 
   proxyquireCore({ './util':
     { getLastModifiedFile: getFileStub }
@@ -216,9 +216,9 @@ test('editLastModifiedFile calls editEntry with last file', function(t) {
 });
 
 test('editLastModifiedFile does nothing if no files', function(t) {
-  var getFileStub = sinon.stub().resolves(null);
-  var editEntryStub = sinon.stub();
-  var failAndQuitStub = sinon.stub();
+  const getFileStub = sinon.stub().resolves(null);
+  const editEntryStub = sinon.stub();
+  const failAndQuitStub = sinon.stub();
 
   proxyquireCore({ './util':
     {
@@ -242,15 +242,15 @@ test('editLastModifiedFile does nothing if no files', function(t) {
 });
 
 test('editEntry calls spawn', function(t) {
-  var spawnSpy = sinon.stub();
+  const spawnSpy = sinon.stub();
   proxyquireCore({
     'child_process': {
       spawn: spawnSpy
     }
   });
 
-  var editorCmd = 'MacDown';
-  var entryPath = '/path/to/file.md';
+  const editorCmd = 'MacDown';
+  const entryPath = '/path/to/file.md';
 
   core.editEntry(editorCmd, entryPath);
   t.deepEqual(
@@ -261,22 +261,22 @@ test('editEntry calls spawn', function(t) {
 });
 
 test('getNotebook gets named notebook', function(t) {
-  var notebooks = {
+  const notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' }
   };
-  var expected = notebooks.journal;
+  const expected = notebooks.journal;
 
-  var config = { notebooks: notebooks };
+  const config = { notebooks: notebooks };
   core.getNotebooks = sinon.stub().withArgs(config).returns(notebooks);
 
-  var actual = core.getNotebook(config, ['journal']);
+  const actual = core.getNotebook(config, ['journal']);
   t.deepEqual(actual, expected);
   end(t);
 });
 
 test('getNotebook gets default notebook', function(t) {
-  var notebooks = {
+  const notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' },
     mostUsed: {
@@ -284,30 +284,31 @@ test('getNotebook gets default notebook', function(t) {
       default: true
     }
   };
-  var expected = notebooks.mostUsed;
-  var config = { notebooks: notebooks };
+  const expected = notebooks.mostUsed;
+  const config = { notebooks: notebooks };
   core.getNotebooks = sinon.stub().withArgs(config).returns(notebooks);
 
-  var actual = core.getNotebook(config, ['what', 'a', 'great', 'day']);
-  t.deepEqual(actual, expected);
+  const actualWithWords =
+    core.getNotebook(config, ['what', 'a', 'great', 'day']);
+  t.deepEqual(actualWithWords, expected);
 
-  actual = core.getNotebook(config, []);
-  t.deepEqual(actual, expected);
+  const actualNoWords = core.getNotebook(config, []);
+  t.deepEqual(actualNoWords, expected);
 
   end(t);
 });
 
 test('getNotebook throws if no default', function(t) {
-  var notebooks = {
+  const notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' }
   };
 
-  var config = { notebooks: notebooks };
+  const config = { notebooks: notebooks };
   core.getNotebooks = sinon.stub().withArgs(config).returns(notebooks);
-  var expected = new Error('Cannot find notebook. Check name or set default.');
+  const expected = new Error('Cannot find notebook. Check name or set default.');
 
-  var shouldThrow = function() {
+  const shouldThrow = function() {
     core.getNotebook(config, []);
   };
 
@@ -316,33 +317,33 @@ test('getNotebook throws if no default', function(t) {
 });
 
 test('getEntryPath correct when given title', function(t) {
-  var notebook = { path: '/path/to/notebook' };
+  const notebook = { path: '/path/to/notebook' };
   // TODO: These tests are machine-dependent when it comes to time zone. Going
   // to let this slide for now, but should be fixed.
-  var date = new Date('2016-03-05T20:00:00.000Z');
-  var words = ['meeting', 'with', 'vip'];
+  const date = new Date('2016-03-05T20:00:00.000Z');
+  const words = ['meeting', 'with', 'vip'];
 
-  var mkdirpStub = sinon.stub();
+  const mkdirpStub = sinon.stub();
   proxyquireCore({
     'mkdirp': {
       sync: mkdirpStub
     }
   });
   
-  var expected = path.join(
+  const expected = path.join(
     notebook.path, '2016', '2016-03-05_meeting-with-vip.md'
   );
 
-  var actual = core.getEntryPath(notebook, date, words);
+  const actual = core.getEntryPath(notebook, date, words);
   t.equal(actual, expected);
   t.deepEqual(mkdirpStub.args[0], [path.join(notebook.path, '2016')]);
   end(t);
 });
 
 test('getEntryPath correct for no title and default notebook', function(t) {
-  var notebook = { path: '/path/to/notebook' };
-  var date = new Date('2016-12-25T20:00:00.000Z');
-  var words = [];
+  const notebook = { path: '/path/to/notebook' };
+  const date = new Date('2016-12-25T20:00:00.000Z');
+  const words = [];
   
   proxyquireCore({
     'mkdirp': {
@@ -350,24 +351,24 @@ test('getEntryPath correct for no title and default notebook', function(t) {
     }
   });
 
-  var expected = path.join(
+  const expected = path.join(
     notebook.path, '2016', '2016-12-25_daily.md'
   );
 
-  var actual = core.getEntryPath(notebook, date, words);
+  const actual = core.getEntryPath(notebook, date, words);
   t.equal(actual, expected);
   end(t);
 });
 
 test('getEntryTitleWords correct for default notebook, no title', function(t) {
-  var notebook = {
+  const notebook = {
     _name: 'journal',
     default: true
   };
-  var words = [];
+  const words = [];
 
-  var expected = core.DEFAULT_NAME_NO_TITLE;
-  var actual = core.getEntryTitleWords(notebook, words);
+  const expected = core.DEFAULT_NAME_NO_TITLE;
+  const actual = core.getEntryTitleWords(notebook, words);
 
   t.equal(actual, expected);
   end(t);
@@ -375,64 +376,64 @@ test('getEntryTitleWords correct for default notebook, no title', function(t) {
 
 test('getEntryTitleWords correct for default notebook, title in config',
     function(t) {
-  var notebook = {
+  const notebook = {
     _name: 'journal',
     default: true,
     defaultTitle: 'title-son'
   };
-  var words = [];
+  const words = [];
 
-  var expected = notebook.defaultTitle;
-  var actual = core.getEntryTitleWords(notebook, words);
+  const expected = notebook.defaultTitle;
+  const actual = core.getEntryTitleWords(notebook, words);
 
   t.equal(actual, expected);
   end(t);
 });
 
 test('getEntryTitleWords correct for default notebook set title', function(t) {
-  var notebook = {
+  const notebook = {
     _name: 'journal',
     default: true
   };
-  var words = ['meeting', 'with', 'tyrion'];
+  const words = ['meeting', 'with', 'tyrion'];
 
-  var expected = 'meeting-with-tyrion';
-  var actual = core.getEntryTitleWords(notebook, words);
+  const expected = 'meeting-with-tyrion';
+  const actual = core.getEntryTitleWords(notebook, words);
 
   t.equal(actual, expected);
   end(t);
 });
 
 test('getEntryTitleWords correct for custom notebook, no title', function(t) {
-  var notebook = {
+  const notebook = {
     _name: 'notes',
     default: false
   };
-  var words = [];
+  const words = [];
 
-  var expected = core.DEFAULT_NAME_NO_TITLE;
-  var actual = core.getEntryTitleWords(notebook, words);
+  const expected = core.DEFAULT_NAME_NO_TITLE;
+  const actual = core.getEntryTitleWords(notebook, words);
 
   t.equal(actual, expected);
   end(t);
 });
 
 test('getEntryTitleWords correct for custom notebook set title', function(t) {
-  var notebook = {
+  const notebook = {
     _name: 'journal',
     default: false
   };
-  var words = ['notes', 'on', 'winterfell'];
+  const words = ['notes', 'on', 'winterfell'];
 
-  var expected = 'notes-on-winterfell';
-  var actual = core.getEntryTitleWords(notebook, words);
+  const expected = 'notes-on-winterfell';
+  const actual = core.getEntryTitleWords(notebook, words);
 
   t.equal(actual, expected);
   end(t);
 });
 
 test('getNotebooks resolves paths and adds aliases', function(t) {
-  var config = {
+  const config = {
     notebooks: {
       journal: {
         path: '~/path/to/journal',
@@ -446,19 +447,19 @@ test('getNotebooks resolves paths and adds aliases', function(t) {
     }
   };
 
-  var expectedJournal = {
+  const expectedJournal = {
     path: '/abs/path/to/journal',
     aliases: config.notebooks.journal.aliases,
     otherVal: config.notebooks.journal.otherVal,
     default: config.notebooks.journal.default,
     _name: 'journal'
   };
-  var expectedNotes = {
+  const expectedNotes = {
     path: '/abs/path/to/notes',
     _name: 'notes'
   };
 
-  var untildifyStub = sinon.stub();
+  const untildifyStub = sinon.stub();
   untildifyStub.withArgs(config.notebooks.journal.path)
     .returns(expectedJournal.path);
   untildifyStub.withArgs(config.notebooks.notes.path)
@@ -466,14 +467,14 @@ test('getNotebooks resolves paths and adds aliases', function(t) {
 
   proxyquireCore({ 'untildify': untildifyStub });
 
-  var expected = {
+  const expected = {
     journal: expectedJournal,
     j: expectedJournal,
     jrnl: expectedJournal,
     notes: expectedNotes
   };
 
-  var actual = core.getNotebooks(config);
+  const actual = core.getNotebooks(config);
 
   t.deepEqual(actual, expected);
   end(t);

--- a/test/lib/core-test.js
+++ b/test/lib/core-test.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var proxyquire = require('proxyquire');
 var sinon = require('sinon');
-var tape = require('tape');
+var test = require('tape');
 require('sinon-as-promised');
 
 var core = require('../../lib/core');
@@ -42,7 +42,7 @@ function createaCliArgs(configPath, date, editorCmd) {
   };
 }
 
-tape('handleRawInput parses given date and calls next', function(t) {
+test('handleRawInput parses given date and calls next', function(t) {
   var path = 'path/to/config';
   var date = new Date('2016-03-05T20:00:00.000Z');
   var dateArg = 'yesterday';
@@ -65,7 +65,7 @@ tape('handleRawInput parses given date and calls next', function(t) {
   end(t);
 });
 
-tape('handleRawInput gets now if no date given', function(t) {
+test('handleRawInput gets now if no date given', function(t) {
   var path = 'path/to/config';
   var date = new Date('2015-03-05T20:00:00.000Z');
   var dateArg = null;
@@ -88,7 +88,7 @@ tape('handleRawInput gets now if no date given', function(t) {
   end(t);
 });
 
-tape('handleRawInput calls fail and quit on err', function(t) {
+test('handleRawInput calls fail and quit on err', function(t) {
   var expected = { err: 'trouble' };
 
   proxyquireCore({
@@ -105,7 +105,7 @@ tape('handleRawInput calls fail and quit on err', function(t) {
   end(t);
 });
 
-tape('handleValidatedInput opens editor', function(t) {
+test('handleValidatedInput opens editor', function(t) {
   var notebook = { path: '/path/to/notebook' };
   var entryPath = path.join(
     notebook.path, '2016', '2016-03-05_lame-meeting.md'
@@ -128,7 +128,7 @@ tape('handleValidatedInput opens editor', function(t) {
   end(t);
 });
 
-tape('handleValidatedInput calls editLastModifiedFile', function(t) {
+test('handleValidatedInput calls editLastModifiedFile', function(t) {
   var notebook = 'notebook';
   var config = { editRecent: true };
   var words = ['foo', 'bar'];
@@ -148,7 +148,7 @@ tape('handleValidatedInput calls editLastModifiedFile', function(t) {
   end(t);
 });
 
-tape('handleValidatedInput handles pwd', function(t) {
+test('handleValidatedInput handles pwd', function(t) {
   const notebook = 'notebook';
   const config = { pwd: true };
   const words = ['bar', 'baz'];
@@ -170,7 +170,7 @@ tape('handleValidatedInput handles pwd', function(t) {
   end(t);
 });
 
-tape('editLastModifiedFile calls fail and rejects if error', function(t) {
+test('editLastModifiedFile calls fail and rejects if error', function(t) {
   var expected = { err: 'trubs' };
   var getFileStub = sinon.stub().rejects(expected);
 
@@ -189,7 +189,7 @@ tape('editLastModifiedFile calls fail and rejects if error', function(t) {
   });
 });
 
-tape('editLastModifiedFile calls editEntry with last file', function(t) {
+test('editLastModifiedFile calls editEntry with last file', function(t) {
   var notebook = { path: '/Users/cersei/cute-joff' };
   var config = { editorCmd: 'word' };  // Cersei seems like a Word user
 
@@ -215,7 +215,7 @@ tape('editLastModifiedFile calls editEntry with last file', function(t) {
   });
 });
 
-tape('editLastModifiedFile does nothing if no files', function(t) {
+test('editLastModifiedFile does nothing if no files', function(t) {
   var getFileStub = sinon.stub().resolves(null);
   var editEntryStub = sinon.stub();
   var failAndQuitStub = sinon.stub();
@@ -241,7 +241,7 @@ tape('editLastModifiedFile does nothing if no files', function(t) {
 
 });
 
-tape('editEntry calls spawn', function(t) {
+test('editEntry calls spawn', function(t) {
   var spawnSpy = sinon.stub();
   proxyquireCore({
     'child_process': {
@@ -260,7 +260,7 @@ tape('editEntry calls spawn', function(t) {
   end(t);
 });
 
-tape('getNotebook gets named notebook', function(t) {
+test('getNotebook gets named notebook', function(t) {
   var notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' }
@@ -275,7 +275,7 @@ tape('getNotebook gets named notebook', function(t) {
   end(t);
 });
 
-tape('getNotebook gets default notebook', function(t) {
+test('getNotebook gets default notebook', function(t) {
   var notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' },
@@ -297,7 +297,7 @@ tape('getNotebook gets default notebook', function(t) {
   end(t);
 });
 
-tape('getNotebook throws if no default', function(t) {
+test('getNotebook throws if no default', function(t) {
   var notebooks = {
     journal: { path: '/path/j' },
     notes: { path: '/path/n' }
@@ -315,7 +315,7 @@ tape('getNotebook throws if no default', function(t) {
   end(t);
 });
 
-tape('getEntryPath correct when given title', function(t) {
+test('getEntryPath correct when given title', function(t) {
   var notebook = { path: '/path/to/notebook' };
   // TODO: These tests are machine-dependent when it comes to time zone. Going
   // to let this slide for now, but should be fixed.
@@ -339,7 +339,7 @@ tape('getEntryPath correct when given title', function(t) {
   end(t);
 });
 
-tape('getEntryPath correct for no title and default notebook', function(t) {
+test('getEntryPath correct for no title and default notebook', function(t) {
   var notebook = { path: '/path/to/notebook' };
   var date = new Date('2016-12-25T20:00:00.000Z');
   var words = [];
@@ -359,7 +359,7 @@ tape('getEntryPath correct for no title and default notebook', function(t) {
   end(t);
 });
 
-tape('getEntryTitleWords correct for default notebook, no title', function(t) {
+test('getEntryTitleWords correct for default notebook, no title', function(t) {
   var notebook = {
     _name: 'journal',
     default: true
@@ -373,7 +373,7 @@ tape('getEntryTitleWords correct for default notebook, no title', function(t) {
   end(t);
 });
 
-tape('getEntryTitleWords correct for default notebook, title in config',
+test('getEntryTitleWords correct for default notebook, title in config',
     function(t) {
   var notebook = {
     _name: 'journal',
@@ -389,7 +389,7 @@ tape('getEntryTitleWords correct for default notebook, title in config',
   end(t);
 });
 
-tape('getEntryTitleWords correct for default notebook set title', function(t) {
+test('getEntryTitleWords correct for default notebook set title', function(t) {
   var notebook = {
     _name: 'journal',
     default: true
@@ -403,7 +403,7 @@ tape('getEntryTitleWords correct for default notebook set title', function(t) {
   end(t);
 });
 
-tape('getEntryTitleWords correct for custom notebook, no title', function(t) {
+test('getEntryTitleWords correct for custom notebook, no title', function(t) {
   var notebook = {
     _name: 'notes',
     default: false
@@ -417,7 +417,7 @@ tape('getEntryTitleWords correct for custom notebook, no title', function(t) {
   end(t);
 });
 
-tape('getEntryTitleWords correct for custom notebook set title', function(t) {
+test('getEntryTitleWords correct for custom notebook set title', function(t) {
   var notebook = {
     _name: 'journal',
     default: false
@@ -431,7 +431,7 @@ tape('getEntryTitleWords correct for custom notebook set title', function(t) {
   end(t);
 });
 
-tape('getNotebooks resolves paths and adds aliases', function(t) {
+test('getNotebooks resolves paths and adds aliases', function(t) {
   var config = {
     notebooks: {
       journal: {

--- a/test/lib/util-test.js
+++ b/test/lib/util-test.js
@@ -2,7 +2,7 @@
 
 var proxyquire = require('proxyquire');
 var sinon = require('sinon');
-var tape = require('tape');
+var test = require('tape');
 require('sinon-as-promised');
 
 var util = require('../../lib/util');
@@ -29,7 +29,7 @@ function end(t) {
   reset();
 }
 
-tape('getLastModifiedFile resolves null if no files', function(t) {
+test('getLastModifiedFile resolves null if no files', function(t) {
   var getFileStub = sinon.stub().resolves([]);
   util.getFilesInDirectory = getFileStub;
   util.getLastModifiedFile('', [])
@@ -43,7 +43,7 @@ tape('getLastModifiedFile resolves null if no files', function(t) {
   });
 });
 
-tape('getLastModifiedFile rejects if a stat promise rejects', function(t) {
+test('getLastModifiedFile rejects if a stat promise rejects', function(t) {
   var statStub = sinon.stub();
   var expected = { err: 'expected failure' };
   statStub.onCall(0).returns(Promise.resolve('foo'));
@@ -67,7 +67,7 @@ tape('getLastModifiedFile rejects if a stat promise rejects', function(t) {
   });
 });
 
-tape('getLastModifiedFile correctly filters based on mtime', function(t) {
+test('getLastModifiedFile correctly filters based on mtime', function(t) {
   var dir = '/Users/jonsnow/emo-journal';
   var suffixes = ['.md', '.txt'];
 
@@ -105,7 +105,7 @@ tape('getLastModifiedFile correctly filters based on mtime', function(t) {
   });
 });
 
-tape('getFilesInDirectory correct pattern for multiple suffix', function(t) {
+test('getFilesInDirectory correct pattern for multiple suffix', function(t) {
   var dir = '/Users/tyrion/scheme-journal';
   var suffixes = ['.md', '.txt'];
   var globStub = sinon.stub().callsArgWith(2, null, []);
@@ -123,7 +123,7 @@ tape('getFilesInDirectory correct pattern for multiple suffix', function(t) {
   });
 });
 
-tape('getFilesInDirectory resolves all files', function(t) {
+test('getFilesInDirectory resolves all files', function(t) {
   // This will also handle the one suffix pattern case
   var dir = '/Users/tyrion/scheme-journal';
   var suffixes = ['.md'];
@@ -145,7 +145,7 @@ tape('getFilesInDirectory resolves all files', function(t) {
   });
 });
 
-tape('getFilesInDirectory rejects if error', function(t) {
+test('getFilesInDirectory rejects if error', function(t) {
   // This will also handle the one suffix pattern case
   var expected = { err: 'so trouble' };
   var globStub = sinon.stub().callsArgWith(2, expected, []);

--- a/test/lib/util-test.js
+++ b/test/lib/util-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var test = require('tape');
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const test = require('tape');
 require('sinon-as-promised');
 
-var util = require('../../lib/util');
+let util = require('../../lib/util');
 
 /**
  * Manipulating the object directly leads to polluting the require cache. Any
@@ -30,7 +30,7 @@ function end(t) {
 }
 
 test('getLastModifiedFile resolves null if no files', function(t) {
-  var getFileStub = sinon.stub().resolves([]);
+  const getFileStub = sinon.stub().resolves([]);
   util.getFilesInDirectory = getFileStub;
   util.getLastModifiedFile('', [])
   .then(actual => {
@@ -44,14 +44,14 @@ test('getLastModifiedFile resolves null if no files', function(t) {
 });
 
 test('getLastModifiedFile rejects if a stat promise rejects', function(t) {
-  var statStub = sinon.stub();
-  var expected = { err: 'expected failure' };
+  const statStub = sinon.stub();
+  const expected = { err: 'expected failure' };
   statStub.onCall(0).returns(Promise.resolve('foo'));
   statStub.onCall(1).returns(Promise.reject(expected));
   statStub.onCall(2).returns(Promise.resolve('bar'));
 
-  var files = ['a', 'b', 'c'];
-  var getFilesInDirectoryStub = sinon.stub().resolves(files);
+  const files = ['a', 'b', 'c'];
+  const getFilesInDirectoryStub = sinon.stub().resolves(files);
 
   util.getFilesInDirectory = getFilesInDirectoryStub;
   util.statPromisified = statStub;
@@ -68,24 +68,24 @@ test('getLastModifiedFile rejects if a stat promise rejects', function(t) {
 });
 
 test('getLastModifiedFile correctly filters based on mtime', function(t) {
-  var dir = '/Users/jonsnow/emo-journal';
-  var suffixes = ['.md', '.txt'];
+  const dir = '/Users/jonsnow/emo-journal';
+  const suffixes = ['.md', '.txt'];
 
-  var files = ['foo.md', 'bar.md', 'cat.md'];
+  const files = ['foo.md', 'bar.md', 'cat.md'];
   // We want bar.md to be the most recent.
-  var expected = files[1];
+  const expected = files[1];
   // We can compare these using < >, so we'll use ints for simplicity here.
-  var fooStats = {
+  const fooStats = {
     mtime: 100
   };
-  var barStats = {
+  const barStats = {
     mtime: 500
   };
-  var catStats = {
+  const catStats = {
     mtime: 250
   };
 
-  var statStub = sinon.stub();
+  const statStub = sinon.stub();
   statStub.withArgs(files[0]).returns(Promise.resolve(fooStats));
   statStub.withArgs(files[1]).returns(Promise.resolve(barStats));
   statStub.withArgs(files[2]).returns(Promise.resolve(catStats));
@@ -106,14 +106,14 @@ test('getLastModifiedFile correctly filters based on mtime', function(t) {
 });
 
 test('getFilesInDirectory correct pattern for multiple suffix', function(t) {
-  var dir = '/Users/tyrion/scheme-journal';
-  var suffixes = ['.md', '.txt'];
-  var globStub = sinon.stub().callsArgWith(2, null, []);
+  const dir = '/Users/tyrion/scheme-journal';
+  const suffixes = ['.md', '.txt'];
+  const globStub = sinon.stub().callsArgWith(2, null, []);
   proxyquireUtil({ 'glob': globStub });
 
   util.getFilesInDirectory(dir, suffixes)
   .then(() => {
-    var globArgs = globStub.args[0];
+    const globArgs = globStub.args[0];
     t.equal(globArgs[0], '**/*{.md,.txt}');
     end(t);
   })
@@ -125,16 +125,16 @@ test('getFilesInDirectory correct pattern for multiple suffix', function(t) {
 
 test('getFilesInDirectory resolves all files', function(t) {
   // This will also handle the one suffix pattern case
-  var dir = '/Users/tyrion/scheme-journal';
-  var suffixes = ['.md'];
-  var expected = ['foo.md', 'my-secret-journal.md'];
-  var globStub = sinon.stub().callsArgWith(2, null, expected);
+  const dir = '/Users/tyrion/scheme-journal';
+  const suffixes = ['.md'];
+  const expected = ['foo.md', 'my-secret-journal.md'];
+  const globStub = sinon.stub().callsArgWith(2, null, expected);
   proxyquireUtil({ 'glob': globStub });
 
   util.getFilesInDirectory(dir, suffixes)
   .then(actual => {
     t.equal(actual, expected);
-    var globArgs = globStub.args[0];
+    const globArgs = globStub.args[0];
     t.equal(globArgs[0], '**/*.md');
     t.deepEqual(globArgs[1], { cwd: dir, absolute: true });
     end(t);
@@ -147,8 +147,8 @@ test('getFilesInDirectory resolves all files', function(t) {
 
 test('getFilesInDirectory rejects if error', function(t) {
   // This will also handle the one suffix pattern case
-  var expected = { err: 'so trouble' };
-  var globStub = sinon.stub().callsArgWith(2, expected, []);
+  const expected = { err: 'so trouble' };
+  const globStub = sinon.stub().callsArgWith(2, expected, []);
   proxyquireUtil({ 'glob': globStub });
 
   util.getFilesInDirectory('', [])


### PR DESCRIPTION
Updates a few things for #6 . Primarily drops `var`, changes `tape()` to `test()`, which I've come to prefer.

Closes #6.